### PR TITLE
better color conversion accuracy

### DIFF
--- a/src/app/style.css
+++ b/src/app/style.css
@@ -83,14 +83,6 @@ button {
   opacity: 1;
   visibility: visible;
 }
-.color-picker.is-open + .color-overlay {
-  bottom: 0;
-  left: 0;
-  position: fixed;
-  right: 0;
-  top: 0;
-  z-index: 6;
-}
 .color-box,
 .color-picker {
   position: relative;
@@ -238,6 +230,15 @@ button {
 
 .color-options > input {
   max-width: 100%;
+}
+
+.color-overlay {
+  bottom: 0;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 3;
 }
 
 .color-preview,

--- a/src/components/color-details.tsx
+++ b/src/components/color-details.tsx
@@ -11,7 +11,7 @@ export default function ColorDetails(props: {
 }) {
   const colorHEX = props.color.hex;
   const colorHSL = props.color.hsl;
-  const randomColor = () => props.action(getRandomColor().toHex());
+  const randomColor = () => props.action(getRandomColor().toHsl());
 
   return (
     <div className="color-details" role="none">

--- a/src/components/color-harmony.tsx
+++ b/src/components/color-harmony.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, Dispatch, SetStateAction } from "react";
 import { useColor } from "~/lib/color";
+import { type CustomColor } from "~/lib/types";
 import clsx from "clsx";
 
 type Color =
@@ -13,8 +14,8 @@ type Color =
   | "tetradic"
   | "triadic";
 
-export default function ColorHarmony(props: { raw: string }) {
-  const [content, setContent] = useState<Color>("double-split-complementary");
+export default function ColorHarmony(props: { raw: CustomColor }) {
+  const [content, setContent] = useState<Color>("rectangle");
 
   const color = useColor(props.raw);
   const harmony = useMemo(() => {

--- a/src/components/color-options.tsx
+++ b/src/components/color-options.tsx
@@ -2,37 +2,25 @@
 
 import { useState, useRef, Dispatch, SetStateAction, ChangeEvent } from "react";
 import { createPortal } from "react-dom";
-import { useColor, getFormatColor } from "~/lib/color";
+import { useColor } from "~/lib/color";
 import { type CustomColor } from "~/lib/types";
 
-export default function ColorOptions(props: { color: { hex: string }; action: Dispatch<SetStateAction<CustomColor>> }) {
+export default function ColorOptions(props: { raw: string; action: Dispatch<SetStateAction<CustomColor>> }) {
   const [showModal, setShowModal] = useState<boolean>(false);
   const [focusInput, setFocusInput] = useState<boolean>(true);
-  const colorRef = useRef(props.color.hex);
+  const colorRef = useRef(props.raw);
 
-  const colorHEX = props.color.hex;
+  const currentColor = props.raw;
   const getColor = useColor;
 
   const inputColor = (e: ChangeEvent<HTMLInputElement>) => {
     const newColor = getColor(e.target.value);
     const validColor = newColor.isValid();
-    const formatColor = getFormatColor(e.target.value);
 
     if (validColor === true) {
       colorRef.current = e.target.value;
       // console.log("the color is valid, should be change");
-
-      if (formatColor === "hex") {
-        props.action(newColor.toHex());
-      } else if (formatColor === "hsl") {
-        props.action(newColor.toHsl());
-      } else if (formatColor === "hsv") {
-        props.action(newColor.toHsv());
-      } else if (formatColor === "rgb") {
-        props.action(newColor.toRgb());
-      } else {
-        props.action(newColor.toHex());
-      }
+      props.action(newColor.toRgb());
     } else {
       // console.log("the color is not valid, should not be change");
     }
@@ -61,7 +49,7 @@ export default function ColorOptions(props: { color: { hex: string }; action: Di
     setShowModal(!showModal);
 
     if (showModal === false) {
-      colorRef.current = colorHEX;
+      colorRef.current = currentColor;
       setFocusInput(true);
     } else {
       setFocusInput(false);

--- a/src/components/color-picker.tsx
+++ b/src/components/color-picker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, Dispatch, SetStateAction } from "react";
+import { createPortal } from "react-dom";
 import { useColor } from "~/lib/color";
 import type { CustomColor, HsvaColor } from "~/lib/types";
 import clsx from "clsx";
@@ -15,13 +16,13 @@ export default function ColorPicker(props: {
   const [colorPicker, setColorPicker] = useState<boolean>(false);
   const [colorHSV, setColorHSV] = useState<HsvaColor>(useColor(props.color.raw).toHsv());
 
-  const colorRGB = props.color.rgb;
+  const previewColor = props.color.rgb;
   const setColor = props.action;
   const getColor = useColor;
 
   const newColor = (color: HsvaColor | { h: number } | { v: number }) => {
     setColorHSV({ ...colorHSV, ...color });
-    setColor(getColor(colorHSV).toHsl());
+    setColor(getColor(colorHSV).toRgb());
   };
 
   const handleColorPicker = () => setColorPicker(!colorPicker);
@@ -34,7 +35,7 @@ export default function ColorPicker(props: {
         aria-expanded={colorPicker ? true : false}
         aria-controls="color-dialog"
         aria-label={colorPicker ? "close color picker" : "open color picker"}
-        style={{ backgroundColor: colorRGB }}
+        style={{ backgroundColor: previewColor }}
         tabIndex={0}
         onClick={handleColorPicker}
       ></button>
@@ -56,7 +57,8 @@ export default function ColorPicker(props: {
           <ShadeSlider hsva={colorHSV} onChange={newColor} onBlur={handleColorPicker} />
         </div>
       </div>
-      <div className="color-overlay" aria-hidden="true" onClick={handleColorPicker}></div>
+      {colorPicker &&
+        createPortal(<div className="color-overlay" aria-hidden="true" onClick={handleColorPicker} />, document.body)}
     </div>
   );
 }

--- a/src/components/color.tsx
+++ b/src/components/color.tsx
@@ -21,9 +21,9 @@ export default function Color(props: { raw: CustomColor }) {
     <section className="color">
       <ColorPicker color={{ rgb: colorRGB, raw: deferredColor }} action={setColor} />
       <ColorDetails color={{ hex: colorHEX, hsl: colorHSL }} action={setColor}>
-        <ColorOptions color={{ hex: colorHEX }} action={setColor} />
+        <ColorOptions raw={colorHEX} action={setColor} />
       </ColorDetails>
-      <ColorHarmony raw={colorHEX} />
+      <ColorHarmony raw={deferredColor} />
     </section>
   );
 }


### PR DESCRIPTION
since `colord` using RGBA object as internal color format, we should follow to returns color as object not string.

in this case we use hsl and rgb object as input or output for `colord`.
