### PR TITLE
color space range checker

### DIFF
--- a/src/app/color/page.tsx
+++ b/src/app/color/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+import type { ColorQuery } from "~/lib/types";
+import { getColorQuery, getColorPath, switchCssMode } from "~/lib";
+import { permanentRedirect } from "next/navigation";
+import { Suspense } from "react";
+import Preview from "./preview";
+
+type Props = {
+  searchParams: Promise<ColorQuery>;
+};
+
+export async function generateMetadata({
+  searchParams,
+}: Props): Promise<Metadata> {
+  const query = await searchParams;
+  const name = query.mode
+    ? `Color: ${switchCssMode(getColorQuery(query)!)}`
+    : "Color";
+  const path = query.mode ? getColorPath("/color", query) : "/color";
+
+  return {
+    title: name,
+    openGraph: { title: name, url: path },
+    alternates: { canonical: path },
+  };
+}
+
+export default async function ColorPage({ searchParams }: Props) {
+  const query = await searchParams;
+  if (!query.mode) permanentRedirect("/?error=unknown-color-query");
+
+  const color = getColorQuery(query);
+  if (!color) permanentRedirect("/?error=unknown-color-mode");
+
+  return (
+    <Suspense fallback={<Skeleton />}>
+      <Preview color={color} />
+    </Suspense>
+  );
+}
+
+function Skeleton() {
+  return (
+    <div className="px-4">
+      <div className="mx-auto grid max-w-3xl gap-y-8 py-8">
+        <div className="flex">
+          <div className="skeleton aspect-cinema inline-flex w-full rounded-md"></div>
+        </div>
+        <div className="grid gap-y-2">
+          <div className="skeleton h-6"></div>
+          <div className="skeleton h-6"></div>
+          <div className="skeleton h-6"></div>
+          <div className="skeleton h-6"></div>
+          <div className="skeleton h-6"></div>
+          <div className="skeleton h-6"></div>
+          <div className="skeleton h-6"></div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/color/preview.tsx
+++ b/src/app/color/preview.tsx
@@ -1,0 +1,93 @@
+import type { ReactNode } from "react";
+import type { AnyColorMode } from "~/lib/types";
+import { createColor, parseCss, switchCssMode, switchPath } from "~/lib";
+import {
+  CheckRgb,
+  CheckHsl,
+  CheckHwb,
+  CheckLab,
+  CheckLch,
+  CheckOklab,
+  CheckOklch,
+} from "~/features";
+import clsx from "clsx";
+import Link from "next/link";
+
+export default function Preview({ color }: { color: AnyColorMode }) {
+  const currentCss = switchCssMode(color);
+  const { rgb, hsl, hwb, lab, lch, oklab, oklch } = createColor(
+    parseCss(currentCss)!,
+  );
+  const mode = color.mode;
+
+  return (
+    <main className="px-4">
+      <div className="mx-auto grid max-w-3xl gap-y-8 py-8">
+        <div className="flex" style={{ ["--bg" as string]: currentCss }}>
+          <div className="bg-ref aspect-cinema inline-flex w-full rounded-md"></div>
+        </div>
+        <ul
+          role="listbox"
+          aria-label="color space"
+          className="grid gap-y-2 break-words"
+        >
+          <Css color={{ mode: "rgb", ...rgb.color }} isActive={mode === "rgb"}>
+            <CheckRgb color={rgb.color} />
+          </Css>
+          <Css color={{ mode: "hsl", ...hsl.color }} isActive={mode === "hsl"}>
+            <CheckHsl color={hsl.color} />
+          </Css>
+          <Css color={{ mode: "hwb", ...hwb.color }} isActive={mode === "hwb"}>
+            <CheckHwb color={hwb.color} />
+          </Css>
+          <Css color={{ mode: "lch", ...lch.color }} isActive={mode === "lch"}>
+            <CheckLch color={lch.color} />
+          </Css>
+          <Css
+            color={{ mode: "oklch", ...oklch.color }}
+            isActive={mode === "oklch"}
+          >
+            <CheckOklch color={oklch.color} />
+          </Css>
+          <Css color={{ mode: "lab", ...lab.color }} isActive={mode === "lab"}>
+            <CheckLab color={lab.color} />
+          </Css>
+          <Css
+            color={{ mode: "oklab", ...oklab.color }}
+            isActive={mode === "oklab"}
+          >
+            <CheckOklab color={oklab.color} />
+          </Css>
+        </ul>
+      </div>
+    </main>
+  );
+}
+
+function Css({
+  children,
+  color,
+  isActive,
+}: {
+  children: ReactNode;
+  color: AnyColorMode;
+  isActive: boolean;
+}) {
+  return (
+    <li className="inline-grid justify-items-start">
+      <Link
+        href={switchPath("/color", color)}
+        role="option"
+        aria-selected={isActive}
+        className={clsx(
+          "font-mono",
+          isActive
+            ? "font-medium text-gray-800 dark:text-gray-200"
+            : "text-gray-600 dark:text-gray-400",
+        )}
+      >
+        {children}
+      </Link>
+    </li>
+  );
+}

--- a/src/components/color-view.tsx
+++ b/src/components/color-view.tsx
@@ -1,17 +1,26 @@
 "use client";
 
 import { useColor, useMode } from "~/hooks";
-import { switchCss } from "~/lib";
+import { switchColor, switchCss, switchPath } from "~/lib";
+import Link from "next/link";
 
 export default function ColorView() {
   const [color] = useColor();
   const [mode] = useMode();
 
-  const currentColor = switchCss(mode, color);
+  const currentPath = switchPath("/color", switchColor(mode, color));
+  const currentCss = switchCss(mode, color);
 
   return (
-    <div style={{ ["--bg" as string]: currentColor }}>
-      <div className="bg-ref aspect-cinema rounded-md"></div>
+    <div className="flex" style={{ ["--bg" as string]: currentCss }}>
+      <Link
+        aria-label="view color"
+        href={currentPath}
+        className="bg-ref aspect-cinema inline-flex w-full rounded-md"
+        prefetch={false}
+      >
+        <code className="sr-only">{currentCss}</code>
+      </Link>
     </div>
   );
 }

--- a/src/features/check.tsx
+++ b/src/features/check.tsx
@@ -1,0 +1,159 @@
+import type {
+  RgbColor,
+  HslColor,
+  HwbColor,
+  LabColor,
+  LchColor,
+  OklabColor,
+  OklchColor,
+} from "~/lib/types";
+import { round } from "~/utils";
+
+const warning = "text-red-700 dark:text-red-400";
+
+export function CheckRgb({ color }: { color: RgbColor }) {
+  const { r, g, b } = color;
+  const red = round(r * 255);
+  const green = round(g * 255);
+  const blue = round(b * 255);
+
+  return (
+    <code>
+      <span>{`rgb(`}</span>
+      <span className={r < 0 || r > 1 ? warning : undefined}>{red}</span>{" "}
+      <span className={g < 0 || g > 1 ? warning : undefined}>{green}</span>{" "}
+      <span className={b < 0 || b > 1 ? warning : undefined}>{blue}</span>
+      <span>{`)`}</span>
+    </code>
+  );
+}
+
+export function CheckHsl({ color }: { color: HslColor }) {
+  const { h, s, l } = color;
+  const hue = round(h || 0, 2);
+  const saturation = round(s * 100, 2);
+  const lightness = round(l * 100, 2);
+
+  return (
+    <code>
+      <span>{`hsl(`}</span>
+      <span className={h! < 0 || h! > 360 ? warning : undefined}>
+        {hue}
+      </span>{" "}
+      <span className={s < 0 || s > 1 ? warning : undefined}>
+        {`${saturation}%`}
+      </span>{" "}
+      <span className={l < 0 || l > 1 ? warning : undefined}>
+        {`${lightness}%`}
+      </span>
+      <span>{`)`}</span>
+    </code>
+  );
+}
+
+export function CheckHwb({ color }: { color: HwbColor }) {
+  const { h, w, b } = color;
+  const hue = round(h || 0, 2);
+  const whiteness = round(w * 100, 2);
+  const blackness = round(b * 100, 2);
+
+  return (
+    <code>
+      <span>{`hwb(`}</span>
+      <span className={h! < 0 || h! > 360 ? warning : undefined}>
+        {hue}
+      </span>{" "}
+      <span
+        className={w < 0 || w > 1 ? warning : undefined}
+      >{`${whiteness}%`}</span>{" "}
+      <span
+        className={b < 0 || b > 1 ? warning : undefined}
+      >{`${blackness}%`}</span>
+      <span>{`)`}</span>
+    </code>
+  );
+}
+
+export function CheckLab({ color }: { color: LabColor }) {
+  const { l, a, b } = color;
+  const lightness = round(l, 3);
+  const greenRed = round(a, 3);
+  const blueYellow = round(b, 3);
+
+  return (
+    <code>
+      <span>{`lab(`}</span>
+      <span className={l < 0 || l > 100 ? warning : undefined}>
+        {lightness}
+      </span>{" "}
+      <span className={a < -100 || a > 100 ? warning : undefined}>
+        {greenRed}
+      </span>{" "}
+      <span className={b < -100 || b > 100 ? warning : undefined}>
+        {blueYellow}
+      </span>
+      <span>{`)`}</span>
+    </code>
+  );
+}
+
+export function CheckLch({ color }: { color: LchColor }) {
+  const { l, c, h } = color;
+  const lightness = round(l, 3);
+  const chroma = round(c, 3);
+  const hue = round(h || 0, 3);
+
+  return (
+    <code>
+      <span>{`lch(`}</span>
+      <span className={l < 0 || l > 100 ? warning : undefined}>
+        {lightness}
+      </span>{" "}
+      <span className={c < 0 || c > 150 ? warning : undefined}>{chroma}</span>{" "}
+      <span className={h! < 0 || h! > 360 ? warning : undefined}>{hue}</span>
+      <span>{`)`}</span>
+    </code>
+  );
+}
+
+export function CheckOklab({ color }: { color: OklabColor }) {
+  const { l, a, b } = color;
+  const lightness = round(l, 3);
+  const greenRed = round(a, 3);
+  const blueYellow = round(b, 3);
+
+  return (
+    <code>
+      <span>{`oklab(`}</span>
+      <span className={l < 0 || l > 1 ? warning : undefined}>
+        {lightness}
+      </span>{" "}
+      <span className={a < -0.4 || a > 0.4 ? warning : undefined}>
+        {greenRed}
+      </span>{" "}
+      <span className={b < -0.4 || b > 0.4 ? warning : undefined}>
+        {blueYellow}
+      </span>
+      <span>{`)`}</span>
+    </code>
+  );
+}
+
+export function CheckOklch({ color }: { color: OklchColor }) {
+  const { l, c, h } = color;
+  const lightness = round(l, 3);
+  const chroma = round(c, 3);
+  const hue = round(h || 0, 3);
+
+  return (
+    <code>
+      <span>{`oklch(`}</span>
+      <span className={l < 0 || l > 1 ? warning : undefined}>
+        {lightness}
+      </span>{" "}
+      <span className={c < 0 || c > 0.4 ? warning : undefined}>{chroma}</span>{" "}
+      <span className={h! < 0 || h! > 360 ? warning : undefined}>{hue}</span>
+      <span>{`)`}</span>
+    </code>
+  );
+}

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -6,3 +6,13 @@ export { default as InputLab } from "./lab";
 export { default as InputLch } from "./lch";
 export { default as InputOklab } from "./oklab";
 export { default as InputOklch } from "./oklch";
+
+export {
+  CheckRgb,
+  CheckHsl,
+  CheckHwb,
+  CheckLab,
+  CheckLch,
+  CheckOklab,
+  CheckOklch,
+} from "./check";

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -35,6 +35,6 @@ export {
   parseOklch,
 } from "./parse";
 
-export { switchColor, switchCss, switchPath } from "./switch";
+export { switchColor, switchCss, switchPath, switchCssMode } from "./switch";
 
 export { getColorQuery, getColorPath } from "./query";

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -122,7 +122,7 @@ export const getColorPath = (path: string, query: ColorQuery): string => {
     searchParams.set("c", `${c}`);
     searchParams.set("h", `${h}`);
   } else {
-    searchParams.set("error", "unknown-color-mode");
+    searchParams.set("error", "unknown-color-params");
   }
 
   return `${path}?${searchParams.toString()}`;

--- a/src/lib/switch.ts
+++ b/src/lib/switch.ts
@@ -1,36 +1,48 @@
-import type { ColorFormat, AnyColor, AnyColorMode } from "./types";
+import type { ColorFormat, AnyColorMode } from "./types";
 import type { ColorState } from "~/context/store";
+import {
+  formatRgb,
+  formatHsl,
+  formatHwb,
+  formatLab,
+  formatLch,
+  formatOklab,
+  formatOklch,
+} from "./format";
 
-export const switchColor = (mode: ColorFormat, color: ColorState): AnyColor => {
+export const switchColor = (
+  mode: ColorFormat,
+  color: ColorState,
+): AnyColorMode => {
   const { rgb, hsl, hwb, lab, lch, oklab, oklch } = color;
 
   switch (mode) {
     case "rgb": {
-      return rgb.color;
+      return { mode, ...rgb.color };
       break;
     }
     case "hsl": {
-      return hsl.color;
+      return { mode, ...hsl.color };
       break;
     }
     case "hwb": {
-      return hwb.color;
+      return { mode, ...hwb.color };
       break;
     }
     case "lab": {
-      return lab.color;
+      return { mode, ...lab.color };
       break;
     }
     case "lch": {
-      return lch.color;
+      return { mode, ...lch.color };
       break;
     }
     case "oklab": {
-      return oklab.color;
+      return { mode, ...oklab.color };
       break;
     }
     case "oklch": {
-      return oklch.color;
+      return { mode, ...oklch.color };
       break;
     }
   }
@@ -116,4 +128,42 @@ export const switchPath = (path: string, color: AnyColorMode): string => {
   }
 
   return `${path}?${searchParams.toString()}`;
+};
+
+export const switchCssMode = (color: AnyColorMode): string => {
+  switch (color.mode) {
+    case "rgb": {
+      const { r, g, b } = color;
+      return formatRgb({ r, g, b });
+      break;
+    }
+    case "hsl": {
+      const { h, s, l } = color;
+      return formatHsl({ h, s, l });
+      break;
+    }
+    case "hwb": {
+      const { h, w, b } = color;
+      return formatHwb({ h, w, b });
+      break;
+    }
+    case "lab": {
+      const { l, a, b } = color;
+      return formatLab({ l, a, b });
+      break;
+    }
+    case "lch": {
+      const { l, c, h } = color;
+      return formatLch({ l, c, h });
+    }
+    case "oklab": {
+      const { l, a, b } = color;
+      return formatOklab({ l, a, b });
+      break;
+    }
+    case "oklch": {
+      const { l, c, h } = color;
+      return formatOklch({ l, c, h });
+    }
+  }
 };


### PR DESCRIPTION
added dedicated page for color preview, including color space within range checker.

example case when converting lch, oklch, lab, oklab, to rgb, hsl, hwb, the results might be different, so we add warning as color red.
